### PR TITLE
fix(app): #45 Change path for zipfile export

### DIFF
--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -573,9 +573,9 @@ create_interactive_report <-
 
     # add zip archive of all required output files
     suppressMessages({
-      zipfilename <- fs::path(output_dir, paste0(portfolio_name, "_interactive_report.zip"))
       orig_wd <- setwd(output_dir)
       on.exit(setwd(orig_wd), add = TRUE)
+      zipfilename <- paste0(portfolio_name, "_interactive_report.zip")
       utils::zip(zipfile = zipfilename, files = ".", extras = "-q")
       setwd(orig_wd)
     })


### PR DESCRIPTION
Change path for zipfile export. Since the code changes the working directory to `output_dir`, there is no need to construct a filepath without `output_dir` in it, since we can simply export to a simple file in the (now) working directory.

Prior to this change, zip would attempt to write to `output_dir/output_dir/foo.zip`, and now it writes to the path defined in the original `zipfilename`

Closes: #45