### PR TITLE
New pkgdown template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3
-Config/Needs/website: rmi-pacta/pacta.pkgdown.template
+Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate
 VignetteBuilder: knitr
 URL: https://github.com/RMI-PACTA/pacta.portfolio.report
 BugReports: https://github.com/RMI-PACTA/pacta.portfolio.report/issues

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,3 @@
 url: https://rmi-pacta.github.io/pacta.portfolio.report
 template:
-  package: pacta.pkgdown.template
+  package: pacta.pkgdown.rmitemplate


### PR DESCRIPTION
Similar to https://github.com/RMI-PACTA/pacta.portfolio.allocate/pull/28, this will update the pkgdown template to its new name