### PR TITLE
feat: `twodi_sectors` renamed to `pacta_sectors`

### DIFF
--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -15,7 +15,7 @@
 #' @param select_scenario_other a parameter
 #' @param portfolio_allocation_method a parameter
 #' @param scenario_geography a parameter
-#' @param twodi_sectors a parameter
+#' @param pacta_sectors a parameter
 #' @param green_techs a parameter
 #' @param tech_roadmap_sectors a parameter
 #' @param pacta_sectors_not_analysed a parameter
@@ -60,7 +60,7 @@ create_interactive_report <-
            select_scenario_other,
            portfolio_allocation_method = NULL,
            scenario_geography = NULL,
-           twodi_sectors = c("Power", "Automotive", "Oil&Gas", "Coal", "Steel", "Cement", "Aviation"),
+           pacta_sectors = c("Power", "Automotive", "Oil&Gas", "Coal", "Steel", "Cement", "Aviation"),
            green_techs = c("RenewablesCap", "HydroCap", "NuclearCap", "Hybrid", "Electric", "FuelCell", "Hybrid_HDV", "Electric_HDV", "FuelCell_HDV","Electric Arc Furnace"),
            tech_roadmap_sectors = c("Automotive", "Power", "Oil&Gas", "Coal"),
            pacta_sectors_not_analysed = c("Aviation","Cement", "Steel"),
@@ -188,7 +188,7 @@ create_interactive_report <-
         "Equity",
         investor_name,
         portfolio_name,
-        twodi_sectors,
+        pacta_sectors,
         currency_exchange_value
       ) %>%
         translate_df_contents("data_value_pie_equity", dictionary) %>%
@@ -199,7 +199,7 @@ create_interactive_report <-
         "Bonds",
         investor_name,
         portfolio_name,
-        twodi_sectors,
+        pacta_sectors,
         currency_exchange_value
       ) %>%
         translate_df_contents("data_value_pie_bonds", dictionary) %>%
@@ -214,7 +214,7 @@ create_interactive_report <-
       "Equity",
       investor_name,
       portfolio_name,
-      twodi_sectors
+      pacta_sectors
     ) %>%
       translate_df_contents("data_emissions_pie_equity", dictionary) %>%
       export_data_utf8("data_emissions_pie_equity", output_dir = output_dir)
@@ -224,7 +224,7 @@ create_interactive_report <-
       "Bonds",
       investor_name,
       portfolio_name,
-      twodi_sectors
+      pacta_sectors
     ) %>%
       translate_df_contents("data_emissions_pie_bonds", dictionary) %>%
       export_data_utf8("data_emissions_pie_bonds", output_dir = output_dir)
@@ -342,7 +342,7 @@ create_interactive_report <-
           portfolio_name,
           select_scenario_other,
           select_scenario,
-          twodi_sectors,
+          pacta_sectors,
           year_span,
           start_year
         )
@@ -522,7 +522,7 @@ create_interactive_report <-
     } else {
       re_language <- "fr"
     }
-    
+
     suppressMessages(
       bookdown::render_book(
         input = working_template_dir,

--- a/R/prep_emissions_pie.R
+++ b/R/prep_emissions_pie.R
@@ -1,12 +1,12 @@
 prep_emissions_pie <-
-  function(data, asset_type, investor_name, portfolio_name, twodi_sectors) {
+  function(data, asset_type, investor_name, portfolio_name, pacta_sectors) {
     data %>%
       ungroup() %>%
       filter(.data$investor_name == .env$investor_name &
                .data$portfolio_name == .env$portfolio_name) %>%
       filter(.data$asset_type %in% c("Bonds", "Equity")) %>%
       select("asset_type", "sector", "weighted_sector_emissions") %>%
-      mutate(exploded = .data$sector %in% .env$twodi_sectors) %>%
+      mutate(exploded = .data$sector %in% .env$pacta_sectors) %>%
       arrange(.data$asset_type, desc(.data$exploded), .data$sector) %>%
       rename(key = .data$sector, value = .data$weighted_sector_emissions) %>%
       filter(!is.na(.data$key)) %>%

--- a/R/prep_emissions_trajectory.R
+++ b/R/prep_emissions_trajectory.R
@@ -5,7 +5,7 @@ prep_emissions_trajectory <-
            portfolio_name,
            select_scenario_other,
            select_scenario,
-           twodi_sectors,
+           pacta_sectors,
            year_span,
            start_year
          ) {
@@ -36,7 +36,7 @@ prep_emissions_trajectory <-
       filter(!is.nan(.data$plan)) %>%
       pivot_longer(c("plan", "scen"), names_to = "plan") %>%
       unite("name", "sector", "plan", remove = FALSE) %>%
-      mutate(disabled = !.data$sector %in% .env$twodi_sectors) %>%
+      mutate(disabled = !.data$sector %in% .env$pacta_sectors) %>%
       mutate(unit = .env$emissions_units[.data$sector]) %>%
       group_by(.data$asset_class) %>%
       filter(!all(.data$disabled)) %>%

--- a/R/prep_exposure_pie.R
+++ b/R/prep_exposure_pie.R
@@ -3,7 +3,7 @@ prep_exposure_pie <-
            asset_type,
            investor_name,
            portfolio_name,
-           twodi_sectors,
+           pacta_sectors,
            currency_exchange_value) {
     data %>%
       filter(.data$investor_name == .env$investor_name &
@@ -13,7 +13,7 @@ prep_exposure_pie <-
       mutate(across(c("bics_sector", "financial_sector"), as.character)) %>%
       mutate(
         sector =
-          if_else(!.data$financial_sector %in% .env$twodi_sectors,
+          if_else(!.data$financial_sector %in% .env$pacta_sectors,
             "Other",
             .data$financial_sector
           )
@@ -23,7 +23,7 @@ prep_exposure_pie <-
         value = sum(.data$value_usd, na.rm = TRUE) / .env$currency_exchange_value,
         .groups = "drop"
       ) %>%
-      mutate(exploded = .data$sector %in% .env$twodi_sectors) %>%
+      mutate(exploded = .data$sector %in% .env$pacta_sectors) %>%
       arrange(.data$asset_type, desc(.data$exploded), .data$sector) %>%
       rename(key = .data$sector) %>%
       filter(!is.na(.data$key)) %>%

--- a/man/create_interactive_report.Rd
+++ b/man/create_interactive_report.Rd
@@ -18,7 +18,7 @@ create_interactive_report(
   select_scenario_other,
   portfolio_allocation_method = NULL,
   scenario_geography = NULL,
-  twodi_sectors = c("Power", "Automotive", "Oil&Gas", "Coal", "Steel", "Cement",
+  pacta_sectors = c("Power", "Automotive", "Oil&Gas", "Coal", "Steel", "Cement",
     "Aviation"),
   green_techs = c("RenewablesCap", "HydroCap", "NuclearCap", "Hybrid", "Electric",
     "FuelCell", "Hybrid_HDV", "Electric_HDV", "FuelCell_HDV", "Electric Arc Furnace"),
@@ -75,7 +75,7 @@ create_interactive_report(
 
 \item{scenario_geography}{a parameter}
 
-\item{twodi_sectors}{a parameter}
+\item{pacta_sectors}{a parameter}
 
 \item{green_techs}{a parameter}
 


### PR DESCRIPTION
Renames the argument `twodi_sectors` to `pacta_sectors` in a handful of places. 

From the following search: https://github.com/search?q=org%3ARMI-PACTA%20twodi_sectors&type=code
I've identified that this breaking change begets necessary changes in the following repos/ functions (the rest are archived):

- [ ] https://github.com/RMI-PACTA/pacta.interactive.plot/blob/d291638b7d2a2f724a006877ef968745e3b1adea/R/exposure_pie_chart.R#L51
Solved by: https://github.com/RMI-PACTA/pacta.interactive.plot/pull/44

- [ ] https://github.com/RMI-PACTA/workflow.pacta.report/blob/864ee26bfac93e48fb354b93433187e677f86bc3/pacta_03.R#L248
Solved by: https://github.com/RMI-PACTA/workflow.pacta.report/pull/6 

- [ ] https://github.com/RMI-PACTA/workflow.transition.monitor/blob/91eb8b351bf924c278cc039d0ad4cbcb8bc24db2/web_tool_script_3.R#L223
- [ ] https://github.com/RMI-PACTA/workflow.transition.monitor/blob/91eb8b351bf924c278cc039d0ad4cbcb8bc24db2/web_tool_script_3.R#L239
Both solved by: https://github.com/RMI-PACTA/workflow.transition.monitor/pull/294

Note this PR should be merged BEFORE all of the above PRs are merged. Just tracking it here so it's all in one place.

Closes #12 