### PR TITLE
upkeep: add minimal unit testing

### DIFF
--- a/tests/testthat/test-get_report_template_path.R
+++ b/tests/testthat/test-get_report_template_path.R
@@ -1,0 +1,21 @@
+test_that("with no args, passes expected template path", {
+  expect_equal(
+    get_report_template_path(),
+    system.file(
+      "templates",
+      "general_en_template",
+      package = "pacta.portfolio.report"
+    )
+  )
+})
+
+test_that("with args, passes expected template path", {
+  expect_equal(
+    get_report_template_path("GENERAL", "EN"),
+    system.file(
+      "templates",
+      "general_en_template",
+      package = "pacta.portfolio.report"
+    )
+  )
+})

--- a/tests/testthat/test-select_report_template.R
+++ b/tests/testthat/test-select_report_template.R
@@ -2,6 +2,6 @@ test_that("with no args, returns EN template string", {
   expect_equal(select_report_template(), "_en_template")
 })
 
-test_that("with fake args, returnsexpected string structure", {
+test_that("with fake args, returns expected string structure", {
   expect_equal(select_report_template("foo", "bar"), "foo_bar_template")
 })

--- a/tests/testthat/test-select_report_template.R
+++ b/tests/testthat/test-select_report_template.R
@@ -1,0 +1,7 @@
+test_that("with no args, returns EN template string", {
+  expect_equal(select_report_template(), "_en_template")
+})
+
+test_that("with fake args, returnsexpected string structure", {
+  expect_equal(select_report_template("foo", "bar"), "foo_bar_template")
+})


### PR DESCRIPTION
This adds some minimal unit tests to the low-hanging fruit. 

Obviously `create_interactive_report` is the real elephant in the room here, but I want to tackle that in a separate PR/ issue (see #63)

<img width="391" alt="Screenshot 2024-04-16 at 11 29 45" src="https://github.com/RMI-PACTA/pacta.portfolio.report/assets/8741309/93d393f8-5f2a-442d-af2c-03db46f89fa0">

Closes #30