### PR TITLE
fix JS error in trajectory alignment plot

### DIFF
--- a/inst/js/trajectory_alignment.js
+++ b/inst/js/trajectory_alignment.js
@@ -218,7 +218,7 @@ class trajectory_alignment {
       tech_selector = appendOptionsToTechSelector(tech_selector, data, selected_tech);
       resize_inline_text_dropdown(null, tech_selector);
 
-      subdata = data.filter(d => d.technology_translation == tech_selector.value);
+      let subdata = data.filter(d => d.technology_translation == tech_selector.value);
 
       return subdata
     }


### PR DESCRIPTION
mentioned here:
https://github.com/RMI-PACTA/pacta.portfolio.report/pull/54#issuecomment-2039608485

This seemed to be popping up only with current 23Q4 data (which has a wrong scenario name in it), which implies to me that there is some additional problem yet to be discovered, but in any case, this appears to avoid that error and the trajectory alignment plots display on load without any interaction.