### PR TITLE
Increase font size for table header

### DIFF
--- a/inst/2dii_gitbook_style.css
+++ b/inst/2dii_gitbook_style.css
@@ -7,6 +7,10 @@ table td {
   font-size: 1.6rem !important;
 }
 
+table th {
+  font-size: 1.6rem !important;
+}
+
 /* add line under the chapter numbers */
 .level1 .header-section-number {
   display: inline-block;


### PR DESCRIPTION
In this PR I add css specs for table font size so that a table with a header has the same sized header as the rest of the text.

This PR is related (but not required for it to work) to the update of general templates: https://github.com/RMI-PACTA/templates.transition.monitor/pull/23

Testing the results here: https://github.com/RMI-PACTA/workflow.transition.monitor/pull/343 (table in the annex)