### PR TITLE
feat: adapt and pass through FPRE real estate data from `user_results` into `50_Outputs`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.portfolio.report
 Title: pacta.portfolio.report
-Version: 0.4.1.9000
+Version: 0.4.1.9001
 Authors@R: 
     c(person(given = "Monika",
              family = "Furdyna",

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -105,27 +105,12 @@ create_interactive_report <-
     file.copy(inst_path("webfonts"), to = output_dir, overwrite = TRUE, recursive = TRUE)
     file.copy(inst_path("font"), to = output_dir, overwrite = TRUE, recursive = TRUE)
 
-    if (length(list.files(real_estate_dir)) > 0) {
-      fs::dir_copy(
-        fs::path(real_estate_dir, "pdf"),
-        fs::path(output_dir, "real_estate"),
-        overwrite = TRUE
-        )
-    }
-
     survey_dir <- fs::path(survey_dir, toupper(language_select))
     if (dir.exists(survey_dir)) {
       dir.create(fs::path(output_dir, "survey"), showWarnings = FALSE)
       survey_files <- list.files(survey_dir,full.names = TRUE)
       file.copy(survey_files, to = fs::path(output_dir, "survey"), overwrite = TRUE, recursive = TRUE)
     }
-
-    # real estate path ---------------------------------------------------------
-
-    real_estate_file <- fs::path(output_dir, "real_estate") |>
-      fs::dir_info() |>
-      dplyr::filter(grepl("es_.*_de", path)) |>
-      dplyr::pull(path)
 
     # translations -------------------------------------------------------------
 
@@ -475,6 +460,15 @@ create_interactive_report <-
     # confirm with Wim as to whether the dir won't exist if there are no results to print
     if (length(list.files(real_estate_dir)) > 0) {
       real_estate_flag <- TRUE
+      fs::dir_copy(
+        fs::path(real_estate_dir, "pdf"),
+        fs::path(output_dir, "real_estate"),
+        overwrite = TRUE
+      )
+      real_estate_file <- fs::path(output_dir, "real_estate") |>
+        fs::dir_info() |>
+        dplyr::filter(grepl("es_.*_de", path)) |>
+        dplyr::pull(path)
     }
 
 

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -106,10 +106,11 @@ create_interactive_report <-
     file.copy(inst_path("font"), to = output_dir, overwrite = TRUE, recursive = TRUE)
 
     if (length(list.files(real_estate_dir)) > 0) {
-      if (dir.exists(path(real_estate_dir, "img"))) {
-        file.copy(path(real_estate_dir, "img"), to = fs::path(output_dir), overwrite = TRUE, recursive = TRUE)
-        file.copy(path(real_estate_dir, "img"), to = fs::path(template_dir, "rmd"), overwrite = TRUE, recursive = TRUE)
-      }
+      fs::dir_copy(
+        fs::path(real_estate_dir, "pdf"),
+        fs::path(output_dir, "real_estate"),
+        overwrite = TRUE
+        )
     }
 
     survey_dir <- fs::path(survey_dir, toupper(language_select))
@@ -118,6 +119,13 @@ create_interactive_report <-
       survey_files <- list.files(survey_dir,full.names = TRUE)
       file.copy(survey_files, to = fs::path(output_dir, "survey"), overwrite = TRUE, recursive = TRUE)
     }
+
+    # real estate path ---------------------------------------------------------
+
+    real_estate_file <- fs::path(output_dir, "real_estate") |>
+      fs::dir_info() |>
+      dplyr::filter(grepl("es_.*_de", path)) |>
+      dplyr::pull(path)
 
     # translations -------------------------------------------------------------
 
@@ -467,8 +475,6 @@ create_interactive_report <-
     # confirm with Wim as to whether the dir won't exist if there are no results to print
     if (length(list.files(real_estate_dir)) > 0) {
       real_estate_flag <- TRUE
-      re_data_input <- jsonlite::read_json(fs::path(real_estate_dir, "data/data.json"))
-      re_config_data <- jsonlite::read_json(fs::path(real_estate_dir, "data/config.json"))
     }
 
 
@@ -533,6 +539,7 @@ create_interactive_report <-
         params = list(
           portfolio_results_flag = portfolio_results_flag,
           real_estate_flag = real_estate_flag,
+          real_estate_file = real_estate_file,
           survey_flag = survey_flag,
           survey_data = survey_data,
           re_config_data = re_config_data,

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -492,6 +492,10 @@ create_interactive_report <-
         }
       }
 
+      fs::dir_create(
+        path = dirname(fs::path(output_dir, re_files_df[["link"]])),
+        recurse = TRUE
+      )
       fs::file_copy(
         path = re_files_df[["source_file"]],
         new_path = fs::path(output_dir, re_files_df[["link"]]),

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -547,13 +547,6 @@ create_interactive_report <-
 
     working_template_dir <- fs::path(temporary_dir, basename(template_dir))
 
-    # This selects the language for the real estate chapter which is only available in DE and FR
-    if (language_select %in% c("EN", "DE")) {
-      re_language <- "de"
-    } else {
-      re_language <- "fr"
-    }
-
     suppressMessages(
       bookdown::render_book(
         input = working_template_dir,
@@ -569,7 +562,7 @@ create_interactive_report <-
           re_config_data = re_config_data,
           re_data_input = re_data_input,
           portfolio_parameters = portfolio_parameters,
-          language = re_language
+          language = language_select,
         )
       )
     )

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -482,8 +482,8 @@ create_interactive_report <-
               source_file = fs::path(
                 real_estate_dir, yy[[report_language]][["file"]]
               ),
-              output_file = fs::path(
-                output_dir, "real_estate",
+              link = fs::path(
+                "real_estate",
                 basename(yy[[report_language]][["file"]])
               ),
               stringsAsFactors = FALSE
@@ -495,7 +495,7 @@ create_interactive_report <-
 
       fs::file_copy(
         path = re_files_df[["source_file"]],
-        new_path = re_files_df[["output_file"]],
+        new_path = fs::path(output_dir, re_files_df[["link"]]),
         overwrite = TRUE
       )
 

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -565,7 +565,7 @@ create_interactive_report <-
           re_config_data = re_config_data,
           re_data_input = re_data_input,
           portfolio_parameters = portfolio_parameters,
-          language = language_select,
+          language = language_select
         )
       )
     )

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -559,11 +559,10 @@ create_interactive_report <-
         params = list(
           portfolio_results_flag = portfolio_results_flag,
           real_estate_flag = real_estate_flag,
-          re_files_df = re_files_df,
           survey_flag = survey_flag,
           survey_data = survey_data,
           re_config_data = re_config_data,
-          re_data_input = re_data_input,
+          re_data_input = re_files_df,
           portfolio_parameters = portfolio_parameters,
           language = language_select
         )

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -457,7 +457,7 @@ create_interactive_report <-
     re_data_input <- NULL
     re_config_data <- NULL
 
-    # confirm with Wim as to whether the dir won't exist if there are no results to print
+    re_files_df <- NULL
     if (length(list.files(real_estate_dir)) > 0) {
       real_estate_flag <- TRUE
 
@@ -466,7 +466,6 @@ create_interactive_report <-
         file.path(real_estate_dir, "reports.json")
       )[["reports"]]
 
-      re_files_df <- NULL
       for (report_type in names(real_estate_files)) {
         xx <- real_estate_files[[report_type]]
         for (yy in xx) {


### PR DESCRIPTION
Update to `create_interactive_report` to handle new Real Estate reports from FPRE. Looks for `reports.json`, and prepares summary table to be passed to template.

Requires coordination with: https://github.com/RMI-PACTA/templates.transition.monitor/pull/34

See https://github.com/RMI-PACTA/workflow.transition.monitor/pull/361 for latest rendered version.