### PR TITLE
Move RE files to under "export"

### DIFF
--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -482,7 +482,7 @@ create_interactive_report <-
                 real_estate_dir, yy[[report_language]][["file"]]
               ),
               link = fs::path(
-                "real_estate",
+                "export", "real_estate",
                 basename(yy[[report_language]][["file"]])
               ),
               stringsAsFactors = FALSE

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -482,7 +482,7 @@ create_interactive_report <-
                 real_estate_dir, yy[[report_language]][["file"]]
               ),
               link = fs::path(
-                "export", "real_estate",
+                "export",
                 basename(yy[[report_language]][["file"]])
               ),
               stringsAsFactors = FALSE


### PR DESCRIPTION
On the CTM platform, it appears that only the `export` subdirectory of the report outputs directory is exposed tot he user. This PR places the RE PDF files in `report/export` rather than `report/real_estate`

Test Results: https://beta.transitionmonitor.com/pacta/share/bc86ff7a-5ed4-4acb-9814-3cf06080d5df