### PR TITLE
Skip entities with no portfolio type

### DIFF
--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -469,7 +469,11 @@ create_interactive_report <-
       for (report_type in names(real_estate_files)) {
         xx <- real_estate_files[[report_type]]
         for (yy in xx) {
-          portfolio_type <- yy[["portfolio_type"]]
+          if (is.null(yy[["portfolio_type"]])) {
+            next
+          } else {
+            portfolio_type <- yy[["portfolio_type"]]
+          }
           portfolio_id <- dplyr::coalesce(yy[["portfolio_id"]], NA_integer_)
           for (report_language in c("de", "fr")) {
             this_report <- data.frame(


### PR DESCRIPTION
Close #97 

PA2024-centric

Checks that an entity within a Real Estate "report type" (executive summary, participant, portfolio) has a "portfolio type" (Direct, mortgage) before processing.

This is primarily to handle an extra empty array that has shown up unexpectedly in the final results. By checking for the `portfolio_type` object, and skipping if it's not there, we can bypass this extra empty list.
