### PR TITLE
bump required R version 3.5.0 -> 4.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Authors@R:
 Description: For more information visit <https://rmi.org/>.
 License: MIT + file LICENSE
 Depends: 
-    R (>= 3.5)
+    R (>= 4.1.0)
 Imports: 
     bookdown (>= 0.38),
     cli,


### PR DESCRIPTION
Since templates in https://github.com/RMI-PACTA/templates.transition.monitor, which are rather critical to this repo's function, use the new native R pipe `|>`, which was introduced in R v4.1.0, seems safest to make it a requirement for this package.