### PR TITLE
add percent pacta sectors content values

### DIFF
--- a/R/calculate_report_content_variables.R
+++ b/R/calculate_report_content_variables.R
@@ -37,29 +37,29 @@ calculate_report_content_variables <-
 
     pacta_sectors_percent_total_value_equity <-
       audit_file %>%
-      filter(.data$valid_input == TRUE) %>%
-      filter(.data$asset_type == "Equity") %>%
-      mutate(pacta_sector = .data$financial_sector %in% .env$pacta_sectors) %>%
-      summarise(
+      dplyr::filter(.data$valid_input == TRUE) %>%
+      dplyr::filter(.data$asset_type == "Equity") %>%
+      dplyr::mutate(pacta_sector = .data$financial_sector %in% .env$pacta_sectors) %>%
+      dplyr::summarise(
         value = sum(.data$value_usd, na.rm = TRUE) / .env$currency_exchange_value,
         .by = "pacta_sector"
       ) %>%
-      mutate(percent = .data$value / sum(.data$value)) %>%
-      filter(.data$pacta_sector == TRUE) %>%
-      pull("percent")
+      dplyr::mutate(percent = .data$value / sum(.data$value)) %>%
+      dplyr::filter(.data$pacta_sector == TRUE) %>%
+      dplyr::pull("percent")
 
     pacta_sectors_percent_total_value_bonds <-
       audit_file %>%
-      filter(.data$valid_input == TRUE) %>%
-      filter(.data$asset_type == "Bonds") %>%
-      mutate(pacta_sector = .data$financial_sector %in% .env$pacta_sectors) %>%
-      summarise(
+      dplyr::filter(.data$valid_input == TRUE) %>%
+      dplyr::filter(.data$asset_type == "Bonds") %>%
+      dplyr::mutate(pacta_sector = .data$financial_sector %in% .env$pacta_sectors) %>%
+      dplyr::summarise(
         value = sum(.data$value_usd, na.rm = TRUE) / .env$currency_exchange_value,
         .by = "pacta_sector"
       ) %>%
-      mutate(percent = .data$value / sum(.data$value)) %>%
-      filter(.data$pacta_sector == TRUE) %>%
-      pull("percent")
+      dplyr::mutate(percent = .data$value / sum(.data$value)) %>%
+      dplyr::filter(.data$pacta_sector == TRUE) %>%
+      dplyr::pull("percent")
 
     results_absolute_value_equity <- audit_file %>%
       filter(.data$asset_type == "Equity", .data$valid_input == TRUE) %>%

--- a/R/create_interactive_report.R
+++ b/R/create_interactive_report.R
@@ -139,7 +139,8 @@ create_interactive_report <-
       audit_file = audit_file,
       investor_name = investor_name,
       portfolio_name = portfolio_name,
-      currency_exchange_value = currency_exchange_value
+      currency_exchange_value = currency_exchange_value,
+      pacta_sectors = pacta_sectors
     )
 
     portfolio_parameters %>%

--- a/inst/templates/general_en_template/rmd/02-scope.Rmd
+++ b/inst/templates/general_en_template/rmd/02-scope.Rmd
@@ -61,7 +61,7 @@ For more information on asset class and sector coverage of PACTA analysis, pleas
 
 As PACTA is a granular and forward looking climate alignment tool, it does not work based on "financed emissions" due to the lack of meaningful scenarios as well as data limitations in measuring these emissions. Nevertheless, estimating current CO2 emissions associated with a portfolio can be useful to inform about the relevance of each sector in the decarbonisation of the portfolio. 
 
-The following charts indicate the contribution of each of the sectors to the total emissions assigned to the equity and bond portfolio. Comparing these graphs to the graphs from the previous section emphasizes the importance of the analysed sectors in terms of climate relevance. While making up `r portfolio_parameters$total_portfolio_percentage_coverage`% of the portfolio value, by emissions the climate relevant sectors are responsible for the following share of the portfolios estimated CO2 emissions.
+The charts below indicate the contribution of each of the sectors to the total emissions assigned to the equity and bond portfolio. Comparing these graphs to the graphs from the previous section emphasizes the importance of the analyzed sectors in terms of climate relevance. While making up `r portfolio_parameters$pacta_sectors_percent_total_value_equity`% of the equity portfolio value, and `r portfolio_parameters$pacta_sectors_percent_total_value_bonds`% of the corporate bond portfolio value, by emissions the PACTA sectors are responsible for the following share of the portfolio’s estimated absolute CO~2~ emissions:
 
 
 <div id="emissions_pie_equity" class="has_optbar donotduplicate donotremove">


### PR DESCRIPTION
- facilitates https://github.com/RMI-PACTA/templates.transition.monitor/pull/60 which will resolve ADO#12312

In the [current template's report text](https://github.com/RMI-PACTA/templates.transition.monitor/blob/d142f3e7a498cc1519f6dac30198987ed4f1d5d8/general_en_template/rmd/02-scope.Rmd#L64), the percentages of covered assets by value for Equity and Bonds should match the percentage values in the sector coverage by value pie charts. However, it is currently using `total_portfolio_percentage_equity` and `total_portfolio_percentage_equity` which is the percent of Equity and Bonds within the total portfolio value.

Since the desired values are not exported by `calculate_report_content_variables()`, this PR adds those values to be exported. Additionally, it utilizes those values in the text of the integrated template. For templates typically used on Transition Monitor, those templates will need to be similarly updated in https://github.com/RMI-PACTA/templates.transition.monitor

The original change in the template text to use these newly desired values occurred in https://github.com/RMI-PACTA/templates.transition.monitor/pull/2 and then an incorrect fix to that occurred in https://github.com/RMI-PACTA/templates.transition.monitor/pull/18

@jdhoffa note that the percentages shown in the value pie charts are calculated within the JavaScript, therefore I had to calculate them separately to make it available for injection into the HTML text:
https://github.com/RMI-PACTA/pacta.portfolio.report/blob/24221e740e947a538702085093a5cb1aa67fa03c/inst/js/PieExploded2.js#L306